### PR TITLE
chore(client): use user-agent to send client version

### DIFF
--- a/Client.UnitTests/RequestMetadataTest.cs
+++ b/Client.UnitTests/RequestMetadataTest.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Grpc.Core;
+using NUnit.Framework;
+
+namespace Zeebe.Client
+{
+    [TestFixture]
+    public class RequestMetadataTest  : BaseZeebeTest
+    {
+
+        [Test]
+        public async Task ShouldUseUserAgentHeader()
+        {
+            // given
+            Metadata sendMetadata = null;
+            TestService.ConsumeRequestHeaders(metadata => { sendMetadata = metadata; });
+
+            // when
+            await ZeebeClient.TopologyRequest().Send();
+
+            // then
+            Assert.NotNull(sendMetadata);
+
+            var entry = sendMetadata[0];
+            Assert.AreEqual("user-agent", entry.Key);
+            Assert.IsTrue(entry.Value.Contains("csharp"));
+            Assert.IsTrue(entry.Value.Contains(typeof(ZeebeClient).Assembly.GetName().Version.ToString()));
+        }
+    }
+}

--- a/Client/ZeebeClient.cs
+++ b/Client/ZeebeClient.cs
@@ -13,6 +13,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using System.Collections.Generic;
+using System.Reflection;
 using GatewayProtocol;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
@@ -41,7 +43,14 @@ namespace Zeebe.Client
         internal ZeebeClient(string address, ChannelCredentials credentials, ILoggerFactory loggerFactory = null)
         {
             this.loggerFactory = loggerFactory;
-            channelToGateway = new Channel(address, credentials);
+
+            var channelOptions = new List<ChannelOption>();
+            var userAgentString = "client: csharp, version: " + typeof(ZeebeClient).Assembly.GetName().Version;
+            var userAgentOption = new ChannelOption(ChannelOptions.PrimaryUserAgentString, userAgentString);
+            channelOptions.Add(userAgentOption);
+
+            channelToGateway =
+                new Channel(address, credentials, channelOptions);
             gatewayClient = new Gateway.GatewayClient(channelToGateway);
         }
 


### PR DESCRIPTION
Sends the client type and version as user-agent header.


closes #110 
