### PR TITLE
Add keepAlive ping

### DIFF
--- a/Client.IntegrationTests/JobWorkerTest.cs
+++ b/Client.IntegrationTests/JobWorkerTest.cs
@@ -12,7 +12,6 @@ namespace Client.IntegrationTests
     public class JobWorkerTest
     {
         private static readonly string DemoProcessPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "oneTaskProcess.bpmn");
-        private static readonly string WorkflowInstanceVariables = "{\"a\":123, \"b\":true}";
 
         private readonly ZeebeIntegrationTestHelper testHelper = new ZeebeIntegrationTestHelper();
         private IZeebeClient zeebeClient;
@@ -79,7 +78,7 @@ namespace Client.IntegrationTests
             // when
             using (zeebeClient.NewWorker()
                 .JobType("oneTask")
-                .Handler(async (jobClient, job) =>handledJobs.Add(job))
+                .Handler((jobClient, job) => handledJobs.Add(job))
                 .MaxJobsActive(1)
                 .AutoCompletion()
                 .Name("csharpWorker")

--- a/Client.UnitTests/RequestMetadataTest.cs
+++ b/Client.UnitTests/RequestMetadataTest.cs
@@ -5,9 +5,8 @@ using NUnit.Framework;
 namespace Zeebe.Client
 {
     [TestFixture]
-    public class RequestMetadataTest  : BaseZeebeTest
+    public class RequestMetadataTest : BaseZeebeTest
     {
-
         [Test]
         public async Task ShouldUseUserAgentHeader()
         {

--- a/Client/Api/Builder/IZeebeClientBuilder.cs
+++ b/Client/Api/Builder/IZeebeClientBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace Zeebe.Client.Api.Builder
@@ -67,6 +68,16 @@ namespace Zeebe.Client.Api.Builder
 
     public interface IZeebeClientFinalBuildStep
     {
+        /// <summary>
+        /// Uses the given time interval to determine when to send a keepalive ping
+        /// to the gateway. The default is 30 seconds.
+        ///
+        /// <p>This is an optional configuration.</p>
+        /// </summary>
+        /// <param name="keepAlive">the timespan between keep alive requests</param>
+        /// <returns>the final step builder</returns>
+        IZeebeClientFinalBuildStep UseKeepAlive(TimeSpan keepAlive);
+
         /// <summary>
         /// Builds the client with the given configuration.
         /// </summary>

--- a/Client/Impl/Builder/ZeebeClientBuilder.cs
+++ b/Client/Impl/Builder/ZeebeClientBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Grpc.Auth;
 using Grpc.Core;
@@ -42,6 +43,7 @@ namespace Zeebe.Client.Impl.Builder
     internal class ZeebePlainClientBuilder : IZeebeClientFinalBuildStep
     {
         private readonly ILoggerFactory loggerFactory;
+        private TimeSpan? keepAlive;
 
         private string Address { get; }
 
@@ -51,15 +53,22 @@ namespace Zeebe.Client.Impl.Builder
             this.loggerFactory = loggerFactory;
         }
 
+        public IZeebeClientFinalBuildStep UseKeepAlive(TimeSpan keepAlive)
+        {
+            this.keepAlive = keepAlive;
+            return this;
+        }
+
         public IZeebeClient Build()
         {
-            return new ZeebeClient(Address, loggerFactory);
+            return new ZeebeClient(Address, keepAlive, loggerFactory);
         }
     }
 
     internal class ZeebeSecureClientBuilder : IZeebeSecureClientBuilder
     {
         private readonly ILoggerFactory loggerFactory;
+        private TimeSpan? keepAlive;
 
         private string Address { get; }
 
@@ -91,9 +100,15 @@ namespace Zeebe.Client.Impl.Builder
             return this;
         }
 
+        public IZeebeClientFinalBuildStep UseKeepAlive(TimeSpan keepAlive)
+        {
+            this.keepAlive = keepAlive;
+            return this;
+        }
+
         public IZeebeClient Build()
         {
-            return new ZeebeClient(Address, Credentials, loggerFactory);
+            return new ZeebeClient(Address, Credentials, keepAlive, loggerFactory);
         }
     }
 }


### PR DESCRIPTION
Adds an optional parameter to set the keepAlive interval.

Use a default configuration of 30 seconds to send periodically keepAlive pings, during an requests
   Useful for workflow instance with result creation.

closes #91
