### PR TITLE
fix(client): close handler thread correctly

### DIFF
--- a/Client/Impl/Worker/JobWorker.cs
+++ b/Client/Impl/Worker/JobWorker.cs
@@ -65,6 +65,13 @@ namespace Zeebe.Client.Impl.Worker
         public void Dispose()
         {
             source.Cancel();
+            // delay disposing, since poll and handler take some time to close
+            Task.Delay(TimeSpan.FromMilliseconds(pollInterval.TotalMilliseconds * 2))
+                .ContinueWith((t) =>
+                {
+                    logger?.LogError("Dispose source");
+                    source.Dispose();
+                });
             isRunning = false;
         }
 
@@ -129,7 +136,7 @@ namespace Zeebe.Client.Impl.Worker
                 }
                 else
                 {
-                    handleSignal.WaitOne();
+                    handleSignal.WaitOne(pollInterval);
                 }
             }
         }


### PR DESCRIPTION
 Previous we wait endless on the handler thread until we get a next job, the problem was that we not check in between whether the worker was already closed/disposed. We now wait the poll interval and check whether we should stop the handler thread.

Furthermore we dispose also the cancelationTokenSource after pollInterval multiplied by 2 to make sure the other threads are closed before.

closes #122 
