### PR TITLE
fix(client): Add delay within catch block in JobWorker.PollJobs to avoid server hogging.

### DIFF
--- a/Client/Impl/Worker/JobWorker.cs
+++ b/Client/Impl/Worker/JobWorker.cs
@@ -145,7 +145,7 @@ namespace Zeebe.Client.Impl.Worker
 
                     try
                     {
-                        var response = await activateJobsCommand.Send(null, cancellationToken);
+                        var response = await activateJobsCommand.SendWithRetry(null, cancellationToken);
                         await HandleActivationResponse(input, response, jobCount);
                     }
                     catch (RpcException rpcException)

--- a/Client/ZeebeClient.cs
+++ b/Client/ZeebeClient.cs
@@ -102,7 +102,7 @@ namespace Zeebe.Client
 
         public IActivateJobsCommandStep1 NewActivateJobsCommand()
         {
-            return new ActivateJobsCommand(gatewayClient);
+            return new ActivateJobsCommand(gatewayClient, asyncRetryStrategy);
         }
 
         public ICompleteJobCommandStep1 NewCompleteJobCommand(long jobKey)


### PR DESCRIPTION
closes #216 
